### PR TITLE
Improve handling of long server names

### DIFF
--- a/client-gui/ServerInfo.cs
+++ b/client-gui/ServerInfo.cs
@@ -54,8 +54,9 @@ namespace ACCConnector {
         }
 
         public void Write(Stream stream) {
+            var serverName = DisplayName[..Math.Min(MAX_SERVER_NAME_LEN_CHARS, DisplayName.Length)];
             var serverNameBuffer = new byte[MAX_SERVER_NAME_LEN_CHARS * 4];
-            var serverNameLenBytes = Encoding.UTF32.GetBytes(DisplayName, serverNameBuffer);
+            var serverNameLenBytes = Encoding.UTF32.GetBytes(serverName, serverNameBuffer);
             var ip = Address.GetAddressBytes();
             var port = Port;
 

--- a/client-gui/ServerInfo.cs
+++ b/client-gui/ServerInfo.cs
@@ -4,7 +4,7 @@ using System.Web;
 
 namespace ACCConnector {
     public class ServerInfo(string? name, string hostname, IPAddress address, ushort port, bool persistent) {
-        private const int MAX_SERVER_NAME_LEN_CHARS = 64;
+        private const int MAX_SERVER_NAME_LEN_CHARS = 256;
 
         public string DisplayName {
             get {

--- a/client-hooks/hooks.c
+++ b/client-hooks/hooks.c
@@ -8,7 +8,7 @@
 
 #define NAMED_PIPE_NAME L"\\\\.\\pipe\\acc-connector-pipe"
 #define MAX_SERVER_ENTRIES 100
-#define MAX_SERVER_NAME_LEN 64
+#define MAX_SERVER_NAME_LEN 256
 #define MAX_SERVER_NAME_LEN_BYTES (MAX_SERVER_NAME_LEN * 4)
 
 #pragma pack(push, 1)


### PR DESCRIPTION
- Fix app crash when a server has a name longer than the maximum, now it will get correctly truncated.
- Increase the maximum allowed server name length to 256 characters to match the maximum allowed by game.

Fixes #18 #17 