### PR TITLE
Fix server names being truncated ingame

### DIFF
--- a/client-gui/ServerInfo.cs
+++ b/client-gui/ServerInfo.cs
@@ -73,7 +73,7 @@ namespace ACCConnector {
             var port = Port;
 
             stream.Write(serverNameBuffer);
-            stream.WriteByte((byte)serverNameLenBytes);
+            stream.WriteByte((byte)serverName.Length);
             stream.Write(ip);
             stream.WriteByte((byte)(port >> 8));
             stream.WriteByte((byte)port);


### PR DESCRIPTION
The name length is supposed to be in UTF32 characters, not bytes.