### PR TITLE
Add support for saving logs to file

### DIFF
--- a/client-gui/ACCHook.cs
+++ b/client-gui/ACCHook.cs
@@ -16,8 +16,8 @@ namespace ACCConnector {
             var exeLocation = Path.GetDirectoryName(Path.GetFullPath(Application.ExecutablePath));
             foreach (var loc in HOOK_DLL_LOCATIONS) {
                 var dllLocation = Path.GetFullPath(Path.Combine([exeLocation!, .. loc]));
-                Trace.WriteLine($"Looking for hook DLL in {dllLocation}");
                 if (File.Exists(dllLocation)) {
+                    Logging.Log(Logging.Severity.DEBUG, $"Using hook DLL from {dllLocation}");
                     return dllLocation;
                 }
             }
@@ -42,7 +42,7 @@ namespace ACCConnector {
             bool found = false;
             if (!User32.EnumWindows(delegate (IntPtr hWnd, IntPtr lParam) {
                 if (IsACCWindow(hWnd)) {
-                    Trace.WriteLine("ACC window found");
+                    Logging.Log(Logging.Severity.DEBUG, $"ACC window found: {hWnd}");
                     found = true;
                 }
                 return true;
@@ -59,19 +59,19 @@ namespace ACCConnector {
         private static IEnumerable<string> FindSteamFolders() {
             using var steamSubKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Wow6432Node\\Valve\\Steam");
             if (steamSubKey == null || steamSubKey.GetValue("InstallPath") is not string steamInstallPath) {
-                Trace.WriteLine("Steam install path not found in registry");
+                Logging.Log(Logging.Severity.ERROR, "Steam install path not found in registry");
                 return Enumerable.Empty<string>();
             }
-            Trace.WriteLine($"Steam installed in {steamInstallPath}");
+            Logging.Log(Logging.Severity.DEBUG, $"Steam installed in {steamInstallPath}");
 
             using var steamFolderReader = new StreamReader(Path.Join(steamInstallPath, "steamapps", "libraryfolders.vdf"), Encoding.UTF8);
             if (VDFSerializer.Deserialize(steamFolderReader).Item2 is not Dictionary<string, object> folderInfo) {
-                Trace.WriteLine("Could not parse Steam library folders");
+                Logging.Log(Logging.Severity.ERROR, "Could not parse Steam library folders");
                 return Enumerable.Empty<string>();
             }
             var steamFolders = from Dictionary<string, object> dict in folderInfo.Values
                                select dict["path"] as string;
-            Trace.WriteLine($"Steam library folders: {String.Join(", ", steamFolders)}");
+            Logging.Log(Logging.Severity.DEBUG, $"Steam library folders: {String.Join(", ", steamFolders)}");
             return steamFolders;
         }
 
@@ -79,10 +79,10 @@ namespace ACCConnector {
             foreach (var f in FindSteamFolders()) {
                 var accManifestPath = Path.Join(f, "steamapps", "appmanifest_805550.acf");
                 if (File.Exists(accManifestPath)) {
-                    Trace.WriteLine($"ACC appmanifest found in {accManifestPath}");
+                    Logging.Log(Logging.Severity.DEBUG, $"ACC appmanifest found in {accManifestPath}");
                     using var acfReader = new StreamReader(accManifestPath, Encoding.UTF8);
                     if (VDFSerializer.Deserialize(acfReader).Item2 is not Dictionary<string, object> accInfo) {
-                        Trace.WriteLine("Could not parse ACC appmanifest");
+                        Logging.Log(Logging.Severity.ERROR, "Could not parse ACC appmanifest");
                         break;
                     }
                     return Path.Join(f, "steamapps", "common", (string)accInfo["installdir"]);
@@ -99,7 +99,7 @@ namespace ACCConnector {
             if (IsHookInstalled(accInstallPath)) {
                 var myInfo = FileVersionInfo.GetVersionInfo(FindHookDLL());
                 var verInfo = FileVersionInfo.GetVersionInfo(InstallPathToDllPath(accInstallPath));
-                Trace.WriteLine($"Installed hook version: {verInfo.ProductVersion} my version {myInfo.ProductVersion}");
+                Logging.Log(Logging.Severity.INFO, $"Installed hook version: {verInfo.ProductVersion} my version {myInfo.ProductVersion}");
                 return myInfo.ProductVersion != verInfo.ProductVersion;
             }
             return false;
@@ -112,13 +112,13 @@ namespace ACCConnector {
         public static void RemoveHook(string accInstallPath) {
             var dllPath = InstallPathToDllPath(accInstallPath);
             File.Delete(InstallPathToDllPath(accInstallPath));
-            Trace.WriteLine($"Deleted hook DLL from {dllPath}");
+            Logging.Log(Logging.Severity.DEBUG, $"Deleted hook DLL from {dllPath}");
         }
 
         public static void InstallHook(string accInstallPath) {
             var dllPath = InstallPathToDllPath(accInstallPath);
             File.Copy(FindHookDLL(), dllPath, true);
-            Trace.WriteLine($"Copied hook DLL to {dllPath}");
+            Logging.Log(Logging.Severity.DEBUG, $"Copied hook DLL to {dllPath}");
         }
     }
 }

--- a/client-gui/Logging.cs
+++ b/client-gui/Logging.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+
+namespace ACCConnector {
+    internal class Logging {
+        public enum Severity {
+            FATAL,
+            ERROR,
+            WARNING,
+            INFO,
+            DEBUG
+        }
+
+        private static StreamWriter? logStream;
+
+        public static void Init(string logFolder) {
+            Directory.CreateDirectory(logFolder);
+            logStream = new StreamWriter(File.Open(Path.Join(logFolder, "app.log"), FileMode.Append, FileAccess.Write, FileShare.Read)) {
+                AutoFlush = true
+            };
+        }
+
+        public static void Log(Severity severity, string msg) {
+            logStream?.WriteLine($"{DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss.fff} {severity}: {msg}");
+            Trace.WriteLine(msg);
+        }
+    }
+}

--- a/client-gui/ServerInfo.cs
+++ b/client-gui/ServerInfo.cs
@@ -39,7 +39,7 @@ namespace ACCConnector {
             try {
                 address = Dns.GetHostAddresses(hostname)[0];
             } catch (SocketException e) {
-                Trace.WriteLine($"Failed to resolve hostname \"{hostname}\": {e.Message}");
+                Logging.Log(Logging.Severity.ERROR, $"Failed to resolve hostname \"{hostname}\": {e.Message}");
             }
 
             return new ServerInfo(name, hostname, address, (ushort)port, persistent);

--- a/client-hooks/client-hooks.h
+++ b/client-hooks/client-hooks.h
@@ -10,3 +10,6 @@ void log_msg(const wchar_t* fmt, ...);
 
 BOOL initProxy();
 void closeProxy();
+
+void initLog();
+void closeLog();

--- a/client-hooks/dllmain.c
+++ b/client-hooks/dllmain.c
@@ -5,6 +5,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD fdwReason, LPVOID lpvReserved)
     switch (fdwReason)
     {
     case DLL_PROCESS_ATTACH:
+        initLog();
         log_msg(L"DLL attaching...");
         if (!initProxy()) {
             log_msg(L"Failed to initialize proxy DLL");
@@ -20,6 +21,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD fdwReason, LPVOID lpvReserved)
         log_msg(L"DLL detaching...");
         removeHooks();
         closeProxy();
+        closeLog();
         break;
 
     case DLL_THREAD_ATTACH:

--- a/client-hooks/hooks.c
+++ b/client-hooks/hooks.c
@@ -45,7 +45,6 @@ void handle_discovery(SOCKET s, DWORD id) {
         log_msg(L"CreateFileW(\"%s\") failed: 0x%x", NAMED_PIPE_NAME, GetLastError());
         return;
     }
-    log_msg(L"CreateFileW done");
 
     DWORD mode = PIPE_READMODE_MESSAGE;
     if (!SetNamedPipeHandleState(hPipe, &mode, NULL, NULL)) {

--- a/client-hooks/log.c
+++ b/client-hooks/log.c
@@ -1,6 +1,35 @@
 #include "client-hooks.h"
 
+#include <Shlobj.h>
+#include <Share.h>
 #include <stdio.h>
+
+FILE* log_file = NULL;
+
+void initLog() {
+    wchar_t *documents_path;
+    HRESULT res = SHGetKnownFolderPath(&FOLDERID_Documents, 0, NULL, &documents_path);
+    if (SUCCEEDED(res)) {
+        wchar_t path[512];
+        swprintf_s(path, 512, L"%s\\ACC Connector", documents_path);
+        CreateDirectory(path, NULL);
+        swprintf_s(path, 512, L"%s\\ACC Connector\\logs", documents_path);
+        CreateDirectory(path, NULL);
+		swprintf_s(path, 512, L"%s\\ACC Connector\\logs\\hook.log", documents_path);
+        log_file = _wfsopen(path, L"a", _SH_DENYWR);
+        CoTaskMemFree(documents_path);
+        log_msg(L"Log opened");
+    }
+    else {
+        log_msg(L"Failed to get Documents folder location: %x", res);
+    }
+}
+
+void closeLog() {
+    log_msg(L"Closing log");
+    fclose(log_file);
+    log_file = NULL;
+}
 
 void log_msg(const wchar_t* fmt, ...) {
     va_list args;
@@ -9,4 +38,11 @@ void log_msg(const wchar_t* fmt, ...) {
     vswprintf_s(buffer, 512, fmt, args);
     va_end(args);
     OutputDebugStringW(buffer);
+    if (log_file) {
+        SYSTEMTIME time;
+        GetLocalTime(&time);
+        fwprintf(log_file, L"%04d-%02d-%02d %02d:%02d:%02d.%03d %s\n",
+            time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute, time.wSecond, time.wMilliseconds, buffer);
+        fflush(log_file);
+    }
 }


### PR DESCRIPTION
Both hook DLL and app logs are now saved to files in `Documents\ACC Connector\logs` so end users can more easily provide information for debugging problems.

Closes #4 