### PR TITLE
Fix two bugs in VDF parsing of KVDict entries

### DIFF
--- a/client-gui/VDFSerializer.cs
+++ b/client-gui/VDFSerializer.cs
@@ -35,6 +35,7 @@ namespace ACCConnector {
         private static Dictionary<string, object> KVDict(TextReader reader) {
             var dict = new Dictionary<string, object>();
             Consume('{', reader);
+            SkipWhitespace(reader);
             while (reader.Peek() != '}') {
                 SkipWhitespace(reader);
                 var key = QuotedString(reader);
@@ -42,6 +43,7 @@ namespace ACCConnector {
                 dict.Add(key, value);
                 SkipWhitespace(reader);
             }
+            Consume('}', reader);
             return dict;
         }
 


### PR DESCRIPTION
Empty KVDict would cause the parser to crash due whitespaces not being consumed correctly, and a missing consume of the closing brace would result in premature stopping of parsing when a KVDict is inside another KVDict.

Fixes #35 