### PR TITLE
Fix sending URI to an already running app instance

### DIFF
--- a/client-gui/MainWindow.cs
+++ b/client-gui/MainWindow.cs
@@ -33,7 +33,9 @@ namespace ACCConnector {
         private void HandleCopyData(User32.COPYDATASTRUCT copydata) {
             switch (copydata.dwData) {
                 case Constants.COPYDATA_SET_URI:
-                    AddFromURI(Marshal.PtrToStringUTF8(copydata.lpData, (int)copydata.cbData));
+                    var uri = Marshal.PtrToStringUTF8(copydata.lpData, (int)copydata.cbData);
+                    Logging.Log(Logging.Severity.DEBUG, $"Add URI request with payload {uri}");
+                    AddFromURI(uri);
                     break;
             }
 

--- a/client-gui/ProgramMain.cs
+++ b/client-gui/ProgramMain.cs
@@ -52,11 +52,23 @@ namespace ACCConnector {
 
         [STAThread]
         static void Main(string[] args) {
-            Logging.Init(Path.Join(GetMyFolder(), "logs"));
-
 #if !DEBUG
             AppDomain.CurrentDomain.UnhandledException += UnhandledException;
 #endif
+
+            string? serverToAdd = null;
+            if (args.Length > 0) {
+                serverToAdd = args[0];
+            }
+
+            IntPtr? openWindowHandle = FindAlreadyOpenWindow();
+            if (openWindowHandle != null && serverToAdd != null) {
+                Logging.Log(Logging.Severity.DEBUG, $"Sending URI {serverToAdd} to window {openWindowHandle}");
+                SendUriToWindow(openWindowHandle.Value, serverToAdd);
+                return;
+            }
+
+            Logging.Init(Path.Join(GetMyFolder(), "logs"));
 
             var settings = Settings.Load();
             if (settings == null) {
@@ -72,20 +84,7 @@ namespace ACCConnector {
                 settings = new Settings { AccInstallPath = accPath };
             }
 
-
             ApplicationConfiguration.Initialize();
-
-            string? serverToAdd = null;
-            if (args.Length > 0) {
-                serverToAdd = args[0];
-            }
-
-            IntPtr? openWindowHandle = FindAlreadyOpenWindow();
-            if (openWindowHandle != null && serverToAdd != null) {
-                Logging.Log(Logging.Severity.INFO, $"Sending URI {serverToAdd} to window {openWindowHandle}");
-                SendUriToWindow(openWindowHandle.Value, serverToAdd);
-                return;
-            }
 
             var serverList = LoadServerList();
             var serverDataLock = new object();


### PR DESCRIPTION
If there is already a running app instance, trying to initialize logging will fail since the logfile will already be open for writing.

Reorder the program startup such that the check for already running instance is done before trying to initialize logging.

This also moves the logging initialization after unhandled exception handler is added so that if similar bugs are introduced in future at least the user will get an error message.

Fixes #37 